### PR TITLE
refactor(): Always use the locale in the file name

### DIFF
--- a/lib/SoyCompiler.js
+++ b/lib/SoyCompiler.js
@@ -12,7 +12,6 @@ var Q = require('q')
 var copy = require('./copy')
 var debug = require('debug')('soynode')
 
-
 /**
  * The key in vmContexts for the default vm context (with no locale).
  */
@@ -247,10 +246,7 @@ SoyCompiler.prototype._compileTemplateFilesAsync = function (inputDir, outputDir
 
   if (options.locales && options.locales.length > 0) {
     args.push('--locales', options.locales.join(','))
-
-    if (options.locales.length > 1) {
-      outputPathFormat = path.join(outputDir, '{LOCALE}', '{INPUT_DIRECTORY}', '{INPUT_FILE_NAME}.js')
-    }
+    outputPathFormat = path.join(outputDir, '{LOCALE}', '{INPUT_DIRECTORY}', '{INPUT_FILE_NAME}.js')
   }
 
   if (options.messageFilePathFormat) {
@@ -562,7 +558,7 @@ SoyCompiler.prototype._preparePrecompiledFile = function (outputDir, precompiled
 SoyCompiler.prototype._concatOutput = function (outputDir, files, vmType) {
   var options = this._options
   var concatFileName = options.concatFileName
-  if (options.locales && options.locales.length > 1) {
+  if (options.locales) {
     concatFileName += '_' + vmType
   }
   concatFileName += '.soy.concat.js'
@@ -584,7 +580,7 @@ SoyCompiler.prototype._concatOutput = function (outputDir, files, vmType) {
 SoyCompiler.prototype._getOutputFile = function (outputDir, file, vmType) {
   var options = this._options
   vmType = vmType || DEFAULT_VM_CONTEXT
-  if (options.locales && options.locales.length > 1) {
+  if (options.locales) {
     return path.join(outputDir, vmType, file) + '.js'
   } else {
     return path.join(outputDir, file) + '.js'


### PR DESCRIPTION
Previously if the `locales` option only included a single locale, soynode created a with name `compiled.soy.concat.js`. I modified it so that the default locale that we use in testing (`en-US`) will output into the same file as during development, when multiple locales are compiled.

Required for this: https://github.com/gawkermedia/kinja-mantle/pull/12867