### PR TITLE
fix(SoyCompiler): Unnecessary log

### DIFF
--- a/lib/SoyCompiler.js
+++ b/lib/SoyCompiler.js
@@ -430,7 +430,6 @@ SoyCompiler.prototype._maybeSetupDynamicRecompile = function (inputDir, outputDi
       fs.watchFile(file, {}, function () {
         var now = Date.now()
         // Ignore spurious change events.
-        debug('caught change to ', file)
         if (now - self._watches[file] < 1000) return Q.resolve(true)
 
         dirtyFileSet[relativeFile] = true


### PR DESCRIPTION
Remove this log because it can show up even if the file is just accessed, not changed.
It's enough to log when it is actually being recompiled (in line 447)